### PR TITLE
consider '.' delimiter for timestamp

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -36,4 +36,10 @@ fn main() {
         let m = parse_message(average_message).unwrap();
         json::encode(&m).unwrap();
     });
+
+    let average_message = r#"<14>1 2017-07-26T14:47:35.869952+05:30 my_hostname custom_appname 5678 some_unique_msgid - \u{feff}Some other message"#;
+    timeit!({
+        let m = parse_message(average_message).unwrap();
+        json::encode(&m).unwrap();
+    });
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -228,7 +228,7 @@ fn parse_timestamp(m: &str) -> Result<(Option<time_t>, &str), ParseErr> {
     tm.tm_min = take_item!(parse_num(rest, 2, 2), rest);
     take_char!(rest, ':');
     tm.tm_sec = take_item!(parse_num(rest, 2, 2), rest);
-    if rest.chars().next() == Some('-') {
+    if rest.chars().next() == Some('.') {
         take_char!(rest, '.');
         take_item!(parse_num(rest, 1, 6), rest);
     }


### PR DESCRIPTION
I'm not 100% sure if '-' is a typo :). Spec is allowing decimal upto 6 digits