### PR TITLE
Serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ time = "^0.1"
 assert_matches = "1.0"
 rustc-serialize = { version = "^0.3", optional = true }
 serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 timeit = "0.1"
+
+[features]
+serde-serialize = ["serde", "serde_derive", "serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ time = "^0.1"
 # this should be a dev dependency, but there's some kind of issue with
 # dev-only macro crates
 assert_matches = "1.0"
-rustc-serialize = "^0.3"
+rustc-serialize = { version = "^0.3", optional = true }
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 timeit = "0.1"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This module implements an [RFC 5424](https://tools.ietf.org/html/rfc5424) IETF S
 
 [Documentation](http://roguelazer.github.io/rust-syslog-rfc5424/syslog_rfc5424/)
 
+This tool supports serializing the parsed messages using rustc-serialize if it's built with the `rustc-serialize`
+feature and using serde if it's built with the `serde` feature.
+
 ## Performance
 
 On a recent system<sup>[1](#sysfootnote)</sup>, a release build takes approximately 8µs to parse an average message and approximately 300ns to parse the smallest legal message. Debug timings are a bit worse -- about 60µs for an average message and about 8µs for the minimal message. A single-threaded Syslog server should be able to parse at least 100,000 messages/s, as long as you run a separate thread for the parser.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This module implements an [RFC 5424](https://tools.ietf.org/html/rfc5424) IETF S
 [Documentation](http://roguelazer.github.io/rust-syslog-rfc5424/syslog_rfc5424/)
 
 This tool supports serializing the parsed messages using rustc-serialize if it's built with the `rustc-serialize`
-feature and using serde if it's built with the `serde` feature.
+feature and using serde if it's built with the `serde-serialize` feature.
 
 ## Performance
 

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -1,13 +1,31 @@
 #[macro_use]
 extern crate timeit;
 extern crate syslog_rfc5424;
+#[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
 
 use syslog_rfc5424::parse_message;
+#[cfg(feature = "rustc-serialize")]
 use rustc_serialize::json;
 
 // Stupid benchmark tool using the timeit! macro because the official benchmarking tools are
 // **still* nightly-Rust-only, even though they're, like, a year old
+
+#[cfg(feature = "rustc-serialize")]
+fn bench_rustc_serialize() {
+    println!("Parsing an average message and encoding it to json with rustc-serialize");
+    let average_message = r#"<29>1 2016-02-21T04:32:57+00:00 web1 someservice - - [origin x-service="someservice"][meta sequenceId="14125553"] 127.0.0.1 - - 1456029177 "GET /v1/ok HTTP/1.1" 200 145 "-" "hacheck 0.9.0" 24306 127.0.0.1:40124 575"#;
+    timeit!({
+        let m = parse_message(average_message).unwrap();
+        json::encode(&m).unwrap();
+    });
+
+    let average_message = r#"<14>1 2017-07-26T14:47:35.869952+05:30 my_hostname custom_appname 5678 some_unique_msgid - \u{feff}Some other message"#;
+    timeit!({
+        let m = parse_message(average_message).unwrap();
+        json::encode(&m).unwrap();
+    });
+}
 
 fn main() {
     println!("Parsing the smallest possible message:");
@@ -30,16 +48,6 @@ fn main() {
     timeit!({
         parse_message(average_message).unwrap();
     });
-    println!("Parsing an average message and encoding it to json");
-    let average_message = r#"<29>1 2016-02-21T04:32:57+00:00 web1 someservice - - [origin x-service="someservice"][meta sequenceId="14125553"] 127.0.0.1 - - 1456029177 "GET /v1/ok HTTP/1.1" 200 145 "-" "hacheck 0.9.0" 24306 127.0.0.1:40124 575"#;
-    timeit!({
-        let m = parse_message(average_message).unwrap();
-        json::encode(&m).unwrap();
-    });
-
-    let average_message = r#"<14>1 2017-07-26T14:47:35.869952+05:30 my_hostname custom_appname 5678 some_unique_msgid - \u{feff}Some other message"#;
-    timeit!({
-        let m = parse_message(average_message).unwrap();
-        json::encode(&m).unwrap();
-    });
+    #[cfg(feature="rustc-serialize")]
+    bench_rustc_serialize();
 }

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -3,6 +3,8 @@ extern crate timeit;
 extern crate syslog_rfc5424;
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
+#[cfg(feature = "serde-serialize")]
+extern crate serde_json;
 
 use syslog_rfc5424::parse_message;
 #[cfg(feature = "rustc-serialize")]
@@ -24,6 +26,22 @@ fn bench_rustc_serialize() {
     timeit!({
         let m = parse_message(average_message).unwrap();
         json::encode(&m).unwrap();
+    });
+}
+
+#[cfg(feature = "serde-serialize")]
+fn bench_serde() {
+    println!("Parsing an average message and encoding it to json with serde");
+    let average_message = r#"<29>1 2016-02-21T04:32:57+00:00 web1 someservice - - [origin x-service="someservice"][meta sequenceId="14125553"] 127.0.0.1 - - 1456029177 "GET /v1/ok HTTP/1.1" 200 145 "-" "hacheck 0.9.0" 24306 127.0.0.1:40124 575"#;
+    timeit!({
+        let m = parse_message(average_message).unwrap();
+        serde_json::to_string(&m).unwrap();
+    });
+
+    let average_message = r#"<14>1 2017-07-26T14:47:35.869952+05:30 my_hostname custom_appname 5678 some_unique_msgid - \u{feff}Some other message"#;
+    timeit!({
+        let m = parse_message(average_message).unwrap();
+        serde_json::to_string(&m).unwrap();
     });
 }
 
@@ -50,4 +68,6 @@ fn main() {
     });
     #[cfg(feature="rustc-serialize")]
     bench_rustc_serialize();
+    #[cfg(feature="serde-serialize")]
+    bench_serde();
 }

--- a/src/facility.rs
+++ b/src/facility.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "rustc-serialize")]
 use rustc_serialize::{Encodable,Encoder};
 
+#[cfg(feature="serde-serialize")]
+use serde::{Serializer, Serialize};
+
 #[derive(Copy,Clone,Debug,PartialEq)]
 #[allow(non_camel_case_types)]
 /// Syslog facilities. Taken From RFC 5424, but I've heard that some platforms mix these around.
@@ -33,7 +36,7 @@ pub enum SyslogFacility {
 }
 
 impl SyslogFacility {
-    /// Convert an int (as used in the wire serialization) into a SyslogFacility
+    /// Convert an int (as used in the wire serialization) into a `SyslogFacility`
     pub fn from_int(i: i32) -> Option<Self> {
         match i {
             0 => Some(SyslogFacility::LOG_KERN),
@@ -63,14 +66,10 @@ impl SyslogFacility {
             _ => None,
         }
     }
-}
 
-
-#[cfg(feature = "rustc-serialize")]
-impl Encodable for SyslogFacility {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error>
-    {
-        s.emit_str(match *self {
+    /// Convert a syslog facility into a unique string representation
+    pub fn as_str(&self) -> &'static str {
+        match *self {
             SyslogFacility::LOG_KERN => "kern",
             SyslogFacility::LOG_USER => "user",
             SyslogFacility::LOG_MAIL => "mail",
@@ -95,6 +94,34 @@ impl Encodable for SyslogFacility {
             SyslogFacility::LOG_LOCAL5 => "local5",
             SyslogFacility::LOG_LOCAL6 => "local6",
             SyslogFacility::LOG_LOCAL7 => "local7",
-        })
+        }
+    }
+}
+
+
+#[cfg(feature = "rustc-serialize")]
+impl Encodable for SyslogFacility {
+    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error>
+    {
+        s.emit_str(self.as_str())
+    }
+}
+
+
+#[cfg(feature = "serde-serialize")]
+impl Serialize for SyslogFacility {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(self.as_str())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::SyslogFacility;
+
+    #[test]
+    fn test_deref() {
+        assert_eq!(SyslogFacility::LOG_KERN.as_str(), "kern");
     }
 }

--- a/src/facility.rs
+++ b/src/facility.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "rustc-serialize")]
 use rustc_serialize::{Encodable,Encoder};
 
 #[derive(Copy,Clone,Debug,PartialEq)]
@@ -65,6 +66,7 @@ impl SyslogFacility {
 }
 
 
+#[cfg(feature = "rustc-serialize")]
 impl Encodable for SyslogFacility {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error>
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,13 @@ extern crate assert_matches;
 extern crate time;
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
+#[cfg(feature = "serde-serialize")]
+extern crate serde;
+#[cfg(feature = "serde-serialize")]
+#[macro_use]
+extern crate serde_derive;
+#[cfg(feature = "serde-serialize")]
+extern crate serde_json;
 
 pub mod message;
 mod severity;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 #[cfg(test)]
 extern crate assert_matches;
 extern crate time;
+#[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
 
 pub mod message;

--- a/src/message.rs
+++ b/src/message.rs
@@ -173,6 +173,12 @@ mod tests {
     #[cfg(feature = "serde-serialize")]
     use serde_json;
     use super::StructuredData;
+    #[cfg(any(feature="serde-serialize", feature="rustc-serialize"))]
+    use super::SyslogMessage;
+    #[cfg(any(feature="serde-serialize", feature="rustc-serialize"))]
+    use severity::SyslogSeverity::*;
+    #[cfg(any(feature="serde-serialize", feature="rustc-serialize"))]
+    use facility::SyslogFacility::*;
 
     #[test]
     fn test_structured_data_basic() {

--- a/src/severity.rs
+++ b/src/severity.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "rustc-serialize")]
 use rustc_serialize::{Encodable,Encoder};
 
 #[derive(Copy,Clone,Debug,PartialEq)]
@@ -35,6 +36,7 @@ impl SyslogSeverity {
 }
 
 
+#[cfg(feature = "rustc-serialize")]
 impl Encodable for SyslogSeverity {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error>
     {

--- a/src/severity.rs
+++ b/src/severity.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "rustc-serialize")]
 use rustc_serialize::{Encodable,Encoder};
 
+#[cfg(feature="serde-serialize")]
+use serde::{Serializer, Serialize};
+
 #[derive(Copy,Clone,Debug,PartialEq)]
 #[allow(non_camel_case_types)]
 /// Syslog Severities from RFC 5424.
@@ -16,7 +19,7 @@ pub enum SyslogSeverity {
 }
 
 impl SyslogSeverity {
-    /// Convert an int (as used in the wire serialization) into a SyslogFacility
+    /// Convert an int (as used in the wire serialization) into a `SyslogSeverity`
     ///
     /// Returns an Option, but the wire protocol will only include 0..7, so should
     /// never return None in practical usage.
@@ -33,14 +36,10 @@ impl SyslogSeverity {
             _ => None,
         }
     }
-}
 
-
-#[cfg(feature = "rustc-serialize")]
-impl Encodable for SyslogSeverity {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error>
-    {
-        s.emit_str(match *self {
+    /// Convert a syslog severity into a unique string representation
+    pub fn as_str(&self) -> &'static str {
+        match *self {
             SyslogSeverity::SEV_EMERG => "emerg",
             SyslogSeverity::SEV_ALERT => "alert",
             SyslogSeverity::SEV_CRIT => "crit",
@@ -49,6 +48,42 @@ impl Encodable for SyslogSeverity {
             SyslogSeverity::SEV_NOTICE => "notice",
             SyslogSeverity::SEV_INFO => "info",
             SyslogSeverity::SEV_DEBUG => "debug"
-        })
+        }
+    }
+}
+
+
+
+#[cfg(feature = "rustc-serialize")]
+impl Encodable for SyslogSeverity {
+    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error>
+    {
+        s.emit_str(self.as_str())
+    }
+}
+
+
+#[cfg(feature = "serde-serialize")]
+impl Serialize for SyslogSeverity {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(self.as_str())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::SyslogSeverity;
+
+    #[test]
+    fn test_deref() {
+        assert_eq!(SyslogSeverity::SEV_EMERG.as_str(), "emerg");
+        assert_eq!(SyslogSeverity::SEV_ALERT.as_str(), "alert");
+        assert_eq!(SyslogSeverity::SEV_CRIT.as_str(), "crit");
+        assert_eq!(SyslogSeverity::SEV_ERR.as_str(), "err");
+        assert_eq!(SyslogSeverity::SEV_WARNING.as_str(), "warning");
+        assert_eq!(SyslogSeverity::SEV_NOTICE.as_str(), "notice");
+        assert_eq!(SyslogSeverity::SEV_INFO.as_str(), "info");
+        assert_eq!(SyslogSeverity::SEV_DEBUG.as_str(), "debug");
     }
 }


### PR DESCRIPTION
   * Makes `rustc-serialize` optional
   * Adds `serde` as another optional dependency via the `serde-serialize` flag
   * Adds appropriate tests

Closes #8 