### PR TITLE
First pass at making this code 3164 compatible:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "syslog_rfc5424"
-version = "0.4.0"
-authors = ["James Brown <roguelazer@roguelazer.com>"]
-description = "Parser for RFC5424 (IETF-format) syslog messages"
-documentation = "http://roguelazer.github.io/rust-syslog-rfc5424/syslog_rfc5424/"
-homepage = "https://github.com/Roguelazer/rust-syslog-rfc5424"
-repository = "https://github.com/Roguelazer/rust-syslog-rfc5424"
+name = "syslog_rfc3164"
+version = "0.1.0"
+authors = ["James Brown <roguelazer@roguelazer.com>", "Xavier Lange <xrlange@tureus.com>"]
+description = "Parser for RFC3164 (IETF-format) syslog messages"
+#documentation = "http://roguelazer.github.io/rust-syslog-rfc5424/syslog_rfc5424/"
+homepage = "https://github.com/tureus/rust-syslog-rfc3164"
+repository = "https://github.com/tureus/rust-syslog-rfc3164"
 license = "ISC"
 readme = "README.md"
 
@@ -14,13 +14,9 @@ time = "^0.1"
 # this should be a dev dependency, but there's some kind of issue with
 # dev-only macro crates
 assert_matches = "1.0"
-rustc-serialize = { version = "^0.3", optional = true }
-serde = { version = "1.0", optional = true }
-serde_derive = { version = "1.0", optional = true }
-serde_json = { version = "1.0", optional = true }
+serde = { version = "1.0" }
+serde_derive = { version = "1.0" }
+serde_json = { version = "1.0" }
 
 [dev-dependencies]
 timeit = "0.1"
-
-[features]
-serde-serialize = ["serde", "serde_derive", "serde_json"]

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2016 James Brown
+Copyright (c) 2016 James Brown, Xavier Lange
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -1,44 +1,22 @@
 #[macro_use]
 extern crate timeit;
-extern crate syslog_rfc5424;
-#[cfg(feature = "rustc-serialize")]
-extern crate rustc_serialize;
-#[cfg(feature = "serde-serialize")]
+extern crate syslog_rfc3164;
 extern crate serde_json;
 
-use syslog_rfc5424::parse_message;
-#[cfg(feature = "rustc-serialize")]
-use rustc_serialize::json;
+use syslog_rfc3164::parse_message;
 
 // Stupid benchmark tool using the timeit! macro because the official benchmarking tools are
 // **still* nightly-Rust-only, even though they're, like, a year old
 
-#[cfg(feature = "rustc-serialize")]
-fn bench_rustc_serialize() {
-    println!("Parsing an average message and encoding it to json with rustc-serialize");
-    let average_message = r#"<29>1 2016-02-21T04:32:57+00:00 web1 someservice - - [origin x-service="someservice"][meta sequenceId="14125553"] 127.0.0.1 - - 1456029177 "GET /v1/ok HTTP/1.1" 200 145 "-" "hacheck 0.9.0" 24306 127.0.0.1:40124 575"#;
-    timeit!({
-        let m = parse_message(average_message).unwrap();
-        json::encode(&m).unwrap();
-    });
-
-    let average_message = r#"<14>1 2017-07-26T14:47:35.869952+05:30 my_hostname custom_appname 5678 some_unique_msgid - \u{feff}Some other message"#;
-    timeit!({
-        let m = parse_message(average_message).unwrap();
-        json::encode(&m).unwrap();
-    });
-}
-
-#[cfg(feature = "serde-serialize")]
 fn bench_serde() {
     println!("Parsing an average message and encoding it to json with serde");
-    let average_message = r#"<29>1 2016-02-21T04:32:57+00:00 web1 someservice - - [origin x-service="someservice"][meta sequenceId="14125553"] 127.0.0.1 - - 1456029177 "GET /v1/ok HTTP/1.1" 200 145 "-" "hacheck 0.9.0" 24306 127.0.0.1:40124 575"#;
+    let average_message = r#"<29>Jan 8 12:14:16 web1 someservice - - [origin x-service="someservice"][meta sequenceId="14125553"] 127.0.0.1 - - 1456029177 "GET /v1/ok HTTP/1.1" 200 145 "-" "hacheck 0.9.0" 24306 127.0.0.1:40124 575"#;
     timeit!({
         let m = parse_message(average_message).unwrap();
         serde_json::to_string(&m).unwrap();
     });
 
-    let average_message = r#"<14>1 2017-07-26T14:47:35.869952+05:30 my_hostname custom_appname 5678 some_unique_msgid - \u{feff}Some other message"#;
+    let average_message = r#"<14>Jan 8 12:14:16 host1 my_hostname custom_appname 5678 some_unique_msgid - \u{feff}Some other message"#;
     timeit!({
         let m = parse_message(average_message).unwrap();
         serde_json::to_string(&m).unwrap();
@@ -47,27 +25,25 @@ fn bench_serde() {
 
 fn main() {
     println!("Parsing the smallest possible message:");
-    let simple_message = "<1>1 - - - - - -";
+    let simple_message = "<1>- - - - - - -";
     timeit!({
         parse_message(simple_message).unwrap();
     });
     println!("Parsing a complicated message:");
-    let complicated_message = "<78>1 2016-01-15T00:04:01Z host1 CROND 10391 - [meta sequenceId=\"29\" sequenceBlah=\"foo\"][my key=\"value\"] some_message";
+    let complicated_message = "<78>Jan 8 12:14:16 host1 CROND no such thing as a complicated message in syslog 3164?";
     timeit!({
         parse_message(complicated_message).unwrap();
     });
     println!("Parsing a very long message:");
-    let large_message = r#"<190>1 2016-02-21T01:19:11+00:00 batch6sj - - - [meta sequenceId="21881798" x-group="37051387"][origin x-service="tracking"] metascutellar conversationalist nephralgic exogenetic graphy streng outtaken acouasm amateurism prenotice Lyonese bedull antigrammatical diosphenol gastriloquial bayoneteer sweetener naggy roughhouser dighter addend sulphacid uneffectless ferroprussiate reveal Mazdaist plaudite Australasian distributival wiseman rumness Seidel topazine shahdom sinsion mesmerically pinguedinous ophthalmotonometer scuppler wound eciliate expectedly carriwitchet dictatorialism bindweb pyelitic idic atule kokoon poultryproof rusticial seedlip nitrosate splenadenoma holobenthic uneternal Phocaean epigenic doubtlessly indirection torticollar robomb adoptedly outspeak wappenschawing talalgia Goop domitic savola unstrafed carded unmagnified mythologically orchester obliteration imperialine undisobeyed galvanoplastical cycloplegia quinquennia foremean umbonal marcgraviaceous happenstance theoretical necropoles wayworn Igbira pseudoangelic raising unfrounced lamasary centaurial Japanolatry microlepidoptera"#;
+    let large_message = r#"<190>Jan 8 12:14:16 host1 CROND metascutellar conversationalist nephralgic exogenetic graphy streng outtaken acouasm amateurism prenotice Lyonese bedull antigrammatical diosphenol gastriloquial bayoneteer sweetener naggy roughhouser dighter addend sulphacid uneffectless ferroprussiate reveal Mazdaist plaudite Australasian distributival wiseman rumness Seidel topazine shahdom sinsion mesmerically pinguedinous ophthalmotonometer scuppler wound eciliate expectedly carriwitchet dictatorialism bindweb pyelitic idic atule kokoon poultryproof rusticial seedlip nitrosate splenadenoma holobenthic uneternal Phocaean epigenic doubtlessly indirection torticollar robomb adoptedly outspeak wappenschawing talalgia Goop domitic savola unstrafed carded unmagnified mythologically orchester obliteration imperialine undisobeyed galvanoplastical cycloplegia quinquennia foremean umbonal marcgraviaceous happenstance theoretical necropoles wayworn Igbira pseudoangelic raising unfrounced lamasary centaurial Japanolatry microlepidoptera"#;
     timeit!({
         parse_message(large_message).unwrap();
     });
     println!("Parsing an average message:");
-    let average_message = r#"<29>1 2016-02-21T04:32:57+00:00 web1 someservice - - [origin x-service="someservice"][meta sequenceId="14125553"] 127.0.0.1 - - 1456029177 "GET /v1/ok HTTP/1.1" 200 145 "-" "hacheck 0.9.0" 24306 127.0.0.1:40124 575"#;
+    let average_message = r#"<29>Jan 8 12:14:16 web1 someservice - - [origin x-service="someservice"][meta sequenceId="14125553"] 127.0.0.1 - - 1456029177 "GET /v1/ok HTTP/1.1" 200 145 "-" "hacheck 0.9.0" 24306 127.0.0.1:40124 575"#;
     timeit!({
         parse_message(average_message).unwrap();
     });
-    #[cfg(feature="rustc-serialize")]
-    bench_rustc_serialize();
-    #[cfg(feature="serde-serialize")]
+
     bench_serde();
 }

--- a/src/facility.rs
+++ b/src/facility.rs
@@ -1,7 +1,3 @@
-#[cfg(feature = "rustc-serialize")]
-use rustc_serialize::{Encodable,Encoder};
-
-#[cfg(feature="serde-serialize")]
 use serde::{Serializer, Serialize};
 
 #[derive(Copy,Clone,Debug,PartialEq)]
@@ -98,17 +94,6 @@ impl SyslogFacility {
     }
 }
 
-
-#[cfg(feature = "rustc-serialize")]
-impl Encodable for SyslogFacility {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error>
-    {
-        s.emit_str(self.as_str())
-    }
-}
-
-
-#[cfg(feature = "serde-serialize")]
 impl Serialize for SyslogFacility {
     fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
         ser.serialize_str(self.as_str())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! A simple syslog server
 //!
 //! ```no_run
-//! use syslog_rfc5424::parse_message;
+//! use syslog_rfc3164::parse_message;
 //! use std::net::UdpSocket;
 //! use std::str;
 //!
@@ -33,14 +33,9 @@
 #[cfg(test)]
 extern crate assert_matches;
 extern crate time;
-#[cfg(feature = "rustc-serialize")]
-extern crate rustc_serialize;
-#[cfg(feature = "serde-serialize")]
 extern crate serde;
-#[cfg(feature = "serde-serialize")]
 #[macro_use]
 extern crate serde_derive;
-#[cfg(feature = "serde-serialize")]
 extern crate serde_json;
 
 pub mod message;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,15 +1,6 @@
 //! In-memory representation of a single Syslog message.
 
 use std::string::String;
-use std::collections::BTreeMap;
-use std::convert::Into;
-use std::ops;
-
-#[cfg(feature = "rustc-serialize")]
-use rustc_serialize::{Encodable,Encoder};
-
-#[cfg(feature="serde-serialize")]
-use serde::{Serializer, Serialize};
 
 #[allow(non_camel_case_types)]
 pub type time_t = i64;
@@ -22,219 +13,25 @@ pub type MessageType = String;
 use severity;
 use facility;
 
-
-#[derive(Clone,Debug,PartialEq,Eq)]
-/// `ProcID`s are usually numeric PIDs; however, on some systems, they may be something else
-pub enum ProcIdType {
-    PID(pid_t),
-    Name(String)
-}
-
-
-#[cfg(feature = "rustc-serialize")]
-impl Encodable for ProcIdType {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error>
-    {
-        match *self {
-            ProcIdType::PID(ref p) => s.emit_i32(*p),
-            ProcIdType::Name(ref n) => s.emit_str(n)
-        }
-    }
-}
-
-
-#[cfg(feature = "serde-serialize")]
-impl Serialize for ProcIdType {
-    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
-        match *self {
-            ProcIdType::PID(ref p) => ser.serialize_i32(*p),
-            ProcIdType::Name(ref n) => ser.serialize_str(n),
-        }
-    }
-}
-
-pub type SDIDType = String;
-pub type SDParamIDType = String;
-pub type SDParamValueType = String;
-
-
-pub type StructuredDataElement = BTreeMap<SDParamIDType, SDParamValueType>;
-
-
-#[derive(Clone,Debug,PartialEq,Eq)]
-/// Container for the `StructuredData` component of a syslog message.
-///
-/// This is a map from `SD_ID` to pairs of `SD_ParamID`, `SD_ParamValue`
-///
-/// The spec does not forbid repeated keys. However, for convenience, we *do* forbid repeated keys.
-/// That is to say, if you have a message like
-///
-/// [foo bar="baz" bar="bing"]
-///
-/// There's no way to retrieve the original "baz" mapping.
-pub struct StructuredData {
-    elements: BTreeMap<SDIDType, StructuredDataElement>,
-}
-
-impl ops::Deref for StructuredData {
-    type Target = BTreeMap<SDIDType, StructuredDataElement>;
-    fn deref(&self) -> &Self::Target {
-        &self.elements
-    }
-}
-
-#[cfg(feature = "rustc-serialize")]
-impl Encodable for StructuredData {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error>
-    {
-        self.elements.encode(s)
-    }
-}
-
-#[cfg(feature = "serde-serialize")]
-impl Serialize for StructuredData {
-    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
-        self.elements.serialize(ser)
-    }
-}
-
-impl StructuredData {
-    pub fn new_empty() -> Self
-    {
-        StructuredData {
-            elements: BTreeMap::new()
-        }
-    }
-
-    /// Insert a new (sd_id, sd_param_id) -> sd_value mapping into the StructuredData
-    pub fn insert_tuple<SI, SPI, SPV> (&mut self, sd_id: SI, sd_param_id: SPI, sd_param_value: SPV) -> ()
-        where SI: Into<SDIDType>, SPI: Into<SDParamIDType>, SPV: Into<SDParamValueType>
-    {
-        let sub_map = self.elements.entry(sd_id.into()).or_insert_with(BTreeMap::new);
-        sub_map.insert(sd_param_id.into(), sd_param_value.into());
-    }
-
-    /// Lookup by SDID, SDParamID pair
-    pub fn find_tuple<'b>(&'b self, sd_id: &str, sd_param_id: &str) -> Option<&'b SDParamValueType>
-    {
-        // TODO: use traits to make these based on the public types isntead of &str
-        if let Some(sub_map) = self.elements.get(sd_id) {
-            if let Some(value) = sub_map.get(sd_param_id) {
-                Some(value)
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    }
-
-    /// Find all param/value mappings for a given SDID
-    pub fn find_sdid<'b>(&'b self, sd_id: &str) -> Option<&'b BTreeMap<SDParamIDType, SDParamValueType>>
-    {
-        self.elements.get(sd_id)
-    }
-
-    /// The number of distinct SD_IDs
-    pub fn len(&self) -> usize
-    {
-        self.elements.len()
-    }
-
-    /// Whether or not this is empty
-    pub fn is_empty(&self) -> bool
-    {
-        self.elements.is_empty()
-    }
-}
-
-
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable))]
-#[cfg_attr(feature = "serde-serialize", derive(Serialize))]
-#[derive(Clone,Debug)]
+#[derive(Clone,Debug,Serialize)]
 pub struct SyslogMessage {
     pub severity: severity::SyslogSeverity,
     pub facility: facility::SyslogFacility,
     pub version: i32,
     pub timestamp: Option<time_t>,
     pub hostname: Option<String>,
-    pub appname: Option<String>,
-    pub procid: Option<ProcIdType>,
-    pub msgid: Option<msgid_t>,
-    pub sd: StructuredData,
+    pub tag: Option<String>,
     pub msg: String,
 }
 
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "rustc-serialize")]
-    use rustc_serialize;
-    #[cfg(feature = "serde-serialize")]
     use serde_json;
-    use super::StructuredData;
-    #[cfg(any(feature="serde-serialize", feature="rustc-serialize"))]
     use super::SyslogMessage;
-    #[cfg(any(feature="serde-serialize", feature="rustc-serialize"))]
     use severity::SyslogSeverity::*;
-    #[cfg(any(feature="serde-serialize", feature="rustc-serialize"))]
     use facility::SyslogFacility::*;
 
-    #[test]
-    fn test_structured_data_basic() {
-        let mut s = StructuredData::new_empty();
-        s.insert_tuple("foo", "bar", "baz");
-        let v = s.find_tuple("foo", "bar").expect("should find foo/bar");
-        assert_eq!(v, "baz");
-        assert!(s.find_tuple("foo", "baz").is_none());
-    }
-
-    #[cfg(feature = "rustc-serialize")]
-    #[test]
-    fn test_structured_data_serialization_rustc_serialize() {
-        let mut s = StructuredData::new_empty();
-        s.insert_tuple("foo", "bar", "baz");
-        s.insert_tuple("foo", "baz", "bar");
-        s.insert_tuple("faa", "bar", "baz");
-        let encoded = rustc_serialize::json::encode(&s).expect("Should encode to JSON");
-        assert_eq!(encoded, r#"{"faa":{"bar":"baz"},"foo":{"bar":"baz","baz":"bar"}}"#);
-    }
-
-    #[cfg(feature = "serde-serialize")]
-    #[test]
-    fn test_structured_data_serialization_serde() {
-        let mut s = StructuredData::new_empty();
-        s.insert_tuple("foo", "bar", "baz");
-        s.insert_tuple("foo", "baz", "bar");
-        s.insert_tuple("faa", "bar", "baz");
-        let encoded = serde_json::to_string(&s).expect("Should encode to JSON");
-        assert_eq!(encoded, r#"{"faa":{"bar":"baz"},"foo":{"bar":"baz","baz":"bar"}}"#);
-    }
-
-    #[cfg(feature = "rustc-serialize")]
-    #[test]
-    fn test_serialization_rustc_serialize() {
-        let m = SyslogMessage {
-            severity: SEV_INFO,
-            facility: LOG_KERN,
-            version: 1,
-            timestamp: None,
-            hostname: None,
-            appname: None,
-            procid: None,
-            msgid: None,
-            sd: StructuredData::new_empty(),
-            msg: String::from("")
-        };
-
-        let encoded = rustc_serialize::json::encode(&m).expect("Should encode to JSON");
-        println!("{:?}", encoded);
-        // XXX: we don't have a guaranteed order, I don't think, so this might break with minor
-        // version changes. *shrug*
-        assert_eq!(encoded, "{\"severity\":\"info\",\"facility\":\"kern\",\"version\":1,\"timestamp\":null,\"hostname\":null,\"appname\":null,\"procid\":null,\"msgid\":null,\"sd\":{},\"msg\":\"\"}");
-    }
-
-    #[cfg(feature = "serde-serialize")]
     #[test]
     fn test_serialization_serde() {
         let m = SyslogMessage {
@@ -243,28 +40,14 @@ mod tests {
             version: 1,
             timestamp: None,
             hostname: None,
-            appname: None,
-            procid: None,
-            msgid: None,
-            sd: StructuredData::new_empty(),
+            tag: None,
             msg: String::from("")
         };
 
         let encoded = serde_json::to_string(&m).expect("Should encode to JSON");
-        println!("{:?}", encoded);
+//        println!("{:?}", encoded);
         // XXX: we don't have a guaranteed order, I don't think, so this might break with minor
         // version changes. *shrug*
-        assert_eq!(encoded, "{\"severity\":\"info\",\"facility\":\"kern\",\"version\":1,\"timestamp\":null,\"hostname\":null,\"appname\":null,\"procid\":null,\"msgid\":null,\"sd\":{},\"msg\":\"\"}");
-    }
-
-    #[test]
-    fn test_deref_structureddata() {
-        let mut s = StructuredData::new_empty();
-        s.insert_tuple("foo", "bar", "baz");
-        s.insert_tuple("foo", "baz", "bar");
-        s.insert_tuple("faa", "bar", "baz");
-        assert_eq!("baz", s.get("foo").and_then(|foo| foo.get("bar")).unwrap());
-        assert_eq!("bar", s.get("foo").and_then(|foo| foo.get("baz")).unwrap());
-        assert_eq!("baz", s.get("faa").and_then(|foo| foo.get("bar")).unwrap());
+        assert_eq!(encoded, "{\"severity\":\"info\",\"facility\":\"kern\",\"version\":1,\"timestamp\":null,\"hostname\":null,\"tag\":null,\"msg\":\"\"}");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::str::FromStr;
 use std::str;
 use std::num;
@@ -9,7 +8,7 @@ use time;
 
 use severity;
 use facility;
-use message::{time_t,SyslogMessage,ProcIdType,StructuredData};
+use message::{time_t,SyslogMessage};
 
 #[derive(Debug)]
 pub enum ParseErr {
@@ -17,6 +16,7 @@ pub enum ParseErr {
     BadSeverityInPri,
     BadFacilityInPri,
     UnexpectedEndOfInput,
+    MonthConversionErr(String),
     TooFewDigits,
     TooManyDigits,
     InvalidUTCOffset,
@@ -45,6 +45,20 @@ macro_rules! maybe_expect_char {
         Some($e) => Some(&$s[1..]),
         _ => None,
     })
+}
+// maybe_take_item!(parse_num(rest, 4, 4), maybe_rest)
+macro_rules! maybe_take_item {
+    ($e:expr, $r:expr) => {{
+        match $e {
+            Ok((v,r)) => {
+                $r = r;
+                Some(v)
+            },
+            Err(_) => {
+                None
+            }
+        }
+    }}
 }
 
 macro_rules! take_item {
@@ -88,104 +102,33 @@ fn take_while<F>(input: &str, f: F, max_chars: usize) -> (&str, Option<&str>)
     ("", None)
 }
 
-fn parse_sd_id(input: &str) -> ParseResult<(String, &str)> {
-    let (res, rest) = take_while(input, |c| c != ' ' && c != '=' && c != ']', 128);
-    Ok((String::from(res), match rest {
-        Some(s) => s,
-        None => { return Err(ParseErr::UnexpectedEndOfInput); }
-    }))
-}
-
-/** Parse a `param_value`... a.k.a. a quoted string */
-fn parse_param_value(input: &str) -> ParseResult<(Cow<str>, &str)> {
-    let mut rest = input;
-    take_char!(rest, '"');
-    // Can't do a 0-copy &str slice here because we need to un-escape escaped quotes
-    // in the string. :-(
-    let mut result = String::new();
-
-    let mut saw_any_escapes = false;
-    let mut escaped = false;
-
-    for (idx, chr) in rest.char_indices() {
-        if escaped {
-            escaped = false
-        } else {
-            if chr == '\\' {
-                escaped = true;
-                if !saw_any_escapes {
-                    result.push_str(&rest[..idx]);
-                }
-                saw_any_escapes = true;
-                continue;
-            }
-            if chr == '"' {
-                let res_cow = if saw_any_escapes {
-                    Cow::Owned(result)
-                } else {
-                    Cow::Borrowed(&rest[..idx])
-                };
-                return Ok((res_cow, &rest[(idx + 1)..]));
-            }
-        }
-        if saw_any_escapes {
-            result.push(chr);
-        }
-    }
-
-    Err(ParseErr::UnexpectedEndOfInput)
-}
-
-type ParsedSDParams = Vec<(String, String)>;
-
-fn parse_sd_params(input: &str) -> ParseResult<(ParsedSDParams, &str)> {
-    let mut params = Vec::new();
-    let mut top = input;
-    loop {
-        if let Some(rest2) = maybe_expect_char!(top, ' ') {
-            let mut rest = rest2;
-            let param_name = take_item!(parse_sd_id(rest), rest);
-            take_char!(rest, '=');
-            let param_value = take_item!(parse_param_value(rest), rest);
-            // is there an uglier modifier than &*
-            params.push((param_name, String::from(&*param_value)));
-            top = rest;
-        } else {
-            return Ok((params, top));
-        }
-    }
-}
-
-fn parse_sde(sde: &str) -> ParseResult<((String, ParsedSDParams), &str)> {
-    let mut rest = sde;
-    take_char!(rest, '[');
-    let id = take_item!(parse_sd_id(rest), rest);
-    let params = take_item!(parse_sd_params(rest), rest);
-    take_char!(rest, ']');
-    Ok(((id, params), rest))
-}
-
-fn parse_sd(structured_data_raw: &str) -> ParseResult<(StructuredData, &str)> {
-    let mut sd = StructuredData::new_empty();
-    if structured_data_raw.starts_with('-') {
-        return Ok((sd, &structured_data_raw[1..]))
-    }
-    let mut rest = structured_data_raw;
-    loop {
-        let (sd_id, params) = take_item!(parse_sde(rest), rest);
-        for (sd_param_id, sd_param_value) in params {
-            sd.insert_tuple(sd_id.clone(), sd_param_id, sd_param_value);
-        }
-        if rest.starts_with(' ') {
-            return Ok((sd, rest));
-        }
-    }
-}
-
 fn parse_pri_val(pri: i32) -> ParseResult<(severity::SyslogSeverity, facility::SyslogFacility)> {
     let sev = severity::SyslogSeverity::from_int(pri & 0x7).ok_or(ParseErr::BadSeverityInPri)?;
     let fac = facility::SyslogFacility::from_int(pri >> 3).ok_or(ParseErr::BadFacilityInPri)?;
     Ok((sev, fac))
+}
+
+fn parse_month(s: &str) -> ParseResult<(i32, &str)> {
+    let (res, rest1) = take_while(s, |c| c >= 'A' && c <= 'z', 3);
+    let rest = rest1.ok_or(ParseErr::UnexpectedEndOfInput)?;
+
+    match res {
+        "Jan" => Ok((1, rest)),
+        "Feb" => Ok((2, rest)),
+        "Mar" => Ok((3, rest)),
+        "Apr" => Ok((4, rest)),
+        "May" => Ok((5, rest)),
+        "Jun" => Ok((6, rest)),
+        "Jul" => Ok((7, rest)),
+        "Aug" => Ok((8, rest)),
+        "Sep" => Ok((9, rest)),
+        "Oct" => Ok((10, rest)),
+        "Nov" => Ok((11, rest)),
+        "Dec" => Ok((12, rest)),
+        _ => Err(ParseErr::MonthConversionErr(res.into()))
+    }
+
+
 }
 
 fn parse_num(s: &str, min_digits: usize, max_digits: usize) -> ParseResult<(i32, &str)> {
@@ -201,47 +144,37 @@ fn parse_num(s: &str, min_digits: usize, max_digits: usize) -> ParseResult<(i32,
 }
 
 fn parse_timestamp(m: &str) -> ParseResult<(Option<time_t>, &str)> {
+    // Jan 8 12:14:16
     let mut rest = m;
     if rest.starts_with('-') {
         return Ok((None, &rest[1..]))
     }
+
     let mut tm = time::empty_tm();
-    tm.tm_year = take_item!(parse_num(rest, 4, 4), rest) - 1900;
-    take_char!(rest, '-');
-    tm.tm_mon = take_item!(parse_num(rest, 2, 2), rest) - 1;
-    take_char!(rest, '-');
-    tm.tm_mday = take_item!(parse_num(rest, 2, 2), rest);
-    take_char!(rest, 'T');
+    tm.tm_mon = take_item!(parse_month(rest), rest) - 1;
+    take_char!(rest, ' ');
+    rest = maybe_expect_char!(rest, ' ').unwrap_or(rest);
+    tm.tm_mday = take_item!(parse_num(rest, 1, 2), rest);
+    take_char!(rest, ' ');
     tm.tm_hour = take_item!(parse_num(rest, 2, 2), rest);
     take_char!(rest, ':');
+
     tm.tm_min = take_item!(parse_num(rest, 2, 2), rest);
     take_char!(rest, ':');
     tm.tm_sec = take_item!(parse_num(rest, 2, 2), rest);
-    if rest.starts_with('.') {
-        take_char!(rest, '.');
-        take_item!(parse_num(rest, 1, 6), rest);
-    }
-    // Tm::utcoff is totally broken, don't use it.
-    let utc_offset_mins = match rest.chars().next() {
-        None => 0,
-        Some('Z') => {
-            rest = &rest[1..];
-            0
+
+    let mut maybe_rest = rest;
+    maybe_rest = maybe_expect_char!(maybe_rest, ' ').unwrap_or(maybe_rest);
+    match maybe_take_item!(parse_num(maybe_rest, 4, 4), maybe_rest) {
+        Some(year) => {
+            tm.tm_year = year - 1900;
+            rest = maybe_rest;
         },
-        Some(c) => {
-            let (sign, irest) = match c {
-                '+' => (1, &rest[1..]),
-                '-' => (-1, &rest[1..]),
-                _ => { return Err(ParseErr::InvalidUTCOffset); }
-            };
-            let hours = i32::from_str(&irest[0..2]).map_err(ParseErr::IntConversionErr)?;
-            let minutes = i32::from_str(&irest[3..5]).map_err(ParseErr::IntConversionErr)?;
-            rest = &irest[5..];
-            minutes + hours * 60 * sign
+        None => {
+            tm.tm_year = time::now().tm_year;
         }
-    };
-    tm = tm + time::Duration::minutes(i64::from(utc_offset_mins));
-    tm.tm_isdst = -1;
+    }
+
     Ok((Some(tm.to_utc().to_timespec().sec), rest))
 }
 
@@ -274,48 +207,26 @@ fn parse_message_s(m: &str) -> ParseResult<SyslogMessage> {
     let prival = take_item!(parse_num(rest, 1, 3), rest);
     take_char!(rest, '>');
     let (sev, fac) = parse_pri_val(prival)?;
-    let version = take_item!(parse_num(rest, 1, 2), rest);
+    // let version = take_item!(parse_num(rest, 1, 2), rest); // TODO: Nuke
     //println!("got version {:?}, rest={:?}", version, rest);
-    take_char!(rest, ' ');
     let timestamp = take_item!(parse_timestamp(rest), rest);
-    //println!("got timestamp {:?}, rest={:?}", timestamp, rest);
     take_char!(rest, ' ');
     let hostname = take_item!(parse_term(rest, 1, 255), rest);
+    take_char!(rest, ' ');
     //println!("got hostname {:?}, rest={:?}", hostname, rest);
+    let tag = take_item!(parse_term(rest, 1, 255), rest);
     take_char!(rest, ' ');
-    let appname = take_item!(parse_term(rest, 1, 48), rest);
-    //println!("got appname {:?}, rest={:?}", appname, rest);
-    take_char!(rest, ' ');
-    let procid_r = take_item!(parse_term(rest, 1, 128), rest);
-    let procid = match procid_r {
-        None => None,
-        Some(s) => Some(match i32::from_str(&s) {
-            Ok(n) => ProcIdType::PID(n),
-            Err(_) => ProcIdType::Name(s)
-        })
-    };
-    //println!("got procid {:?}, rest={:?}", procid, rest);
-    take_char!(rest, ' ');
-    let msgid = take_item!(parse_term(rest, 1, 32), rest);
-    take_char!(rest, ' ');
-    let sd = take_item!(parse_sd(rest), rest);
-    //println!("got sd {:?}, rest={:?}", sd, rest);
-    rest = match maybe_expect_char!(rest, ' ') {
-        Some(r) => r,
-        None => rest
-    };
+    //println!("got tag {:?} rest={:?}", tag, rest)
+
     let msg = String::from(rest);
 
     Ok(SyslogMessage {
         severity: sev,
         facility: fac,
-        version: version,
+        version: 0,
         timestamp: timestamp,
         hostname: hostname,
-        appname: appname,
-        procid: procid,
-        msgid: msgid,
-        sd: sd,
+        tag: tag,
         msg: msg
     })
 }
@@ -335,9 +246,9 @@ fn parse_message_s(m: &str) -> ParseResult<SyslogMessage> {
 /// # Example
 ///
 /// ```
-/// use syslog_rfc5424::parse_message;
+/// use syslog_rfc3164::parse_message;
 ///
-/// let message = parse_message("<78>1 2016-01-15T00:04:01+00:00 host1 CROND 10391 - [meta sequenceId=\"29\"] some_message").unwrap();
+/// let message = parse_message("<78>Mar 15 14:16:22 host1 CROND 10391 - [meta sequenceId=\"29\"] some_message").unwrap();
 ///
 /// assert!(message.hostname.unwrap() == "host1");
 /// ```
@@ -348,115 +259,72 @@ pub fn parse_message<S: AsRef<str>> (s: S) -> ParseResult<SyslogMessage> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_message;
+    use super::{parse_message};
     use message;
 
     use facility::SyslogFacility;
     use severity::SyslogSeverity;
 
+    use time;
+
     #[test]
     fn test_simple() {
-        let msg = parse_message("<1>1 - - - - - -").expect("Should parse empty message");
+        let msg = parse_message("<1>- - - - - -").expect("Should parse empty message");
         assert!(msg.facility == SyslogFacility::LOG_KERN);
         assert!(msg.severity == SyslogSeverity::SEV_ALERT);
         assert!(msg.timestamp.is_none());
         assert!(msg.hostname.is_none());
-        assert!(msg.appname.is_none());
-        assert!(msg.procid.is_none());
-        assert!(msg.msgid.is_none());
-        assert!(msg.sd.len() == 0);
     }
 
     #[test]
-    fn test_with_time_zulu() {
-        let msg = parse_message("<1>1 2015-01-01T00:00:00Z host - - - -").expect("Should parse empty message");
-        assert_eq!(msg.timestamp, Some(1420070400));
+    fn test_timestamp_without_year() {
+        let msg : message::SyslogMessage = parse_message("<1>Jan 8 12:14:16 host tag -").expect("Should parse empty message");
+        let mut tm = time::empty_tm();
+        tm.tm_mon = 0;
+        tm.tm_mday = 8;
+        tm.tm_hour = 12;
+        tm.tm_min = 14;
+        tm.tm_sec = 16;
+        tm.tm_year = time::now().tm_year;
+
+        assert_eq!(msg.timestamp, Some(tm.to_utc().to_timespec().sec));
+        assert_eq!(msg.hostname, Some("host".into()));
+        assert_eq!(msg.tag, Some("tag".into()));
+        assert_eq!(msg.msg, "-");
     }
 
     #[test]
-    fn test_with_time_offset() {
-        let msg = parse_message("<1>1 2015-01-01T00:00:00+00:00 - - - - -").expect("Should parse empty message");
-        assert_eq!(msg.timestamp, Some(1420070400));
-    }
-
-    #[test]
-    fn test_with_time_offset_nonzero() {
-        let msg = parse_message("<1>1 2015-01-01T00:00:00+10:00 - - - - -").expect("Should parse empty message");
-        assert_eq!(msg.timestamp, Some(1420106400));
+    fn test_timestamp_with_year_in_message() {
+        let msg = parse_message("<1>Jan 8 12:14:16 1995 host - - - -").expect("Should parse empty message");
+        assert_eq!(msg.timestamp, Some(789567256));
     }
 
     #[test]
     fn test_complex() {
-        let msg = parse_message("<78>1 2016-01-15T00:04:01+00:00 host1 CROND 10391 - [meta sequenceId=\"29\"] some_message").expect("Should parse complex message");
+        let msg = parse_message("<78>Jan  8 12:14:16 2017 host1 CROND some_message").expect("Should parse complex message");
         assert_eq!(msg.facility, SyslogFacility::LOG_CRON);
         assert_eq!(msg.severity, SyslogSeverity::SEV_INFO);
         assert_eq!(msg.hostname, Some(String::from("host1")));
-        assert_eq!(msg.appname, Some(String::from("CROND")));
-        assert_eq!(msg.procid, Some(message::ProcIdType::PID(10391)));
         assert_eq!(msg.msg, String::from("some_message"));
-        assert_eq!(msg.timestamp, Some(1452816241));
-        assert_eq!(msg.sd.len(), 1);
-        let v = msg.sd.find_tuple("meta", "sequenceId").expect("Should contain meta sequenceId");
-        assert_eq!(v, "29");
+        assert_eq!(msg.timestamp, Some(1483877656));
     }
 
     #[test]
-    fn test_sd_features() {
-        let msg = parse_message("<78>1 2016-01-15T00:04:01Z host1 CROND 10391 - [meta sequenceId=\"29\" sequenceBlah=\"foo\"][my key=\"value\"][meta bar=\"baz=\"] some_message").expect("Should parse complex message");
-        assert_eq!(msg.facility, SyslogFacility::LOG_CRON);
-        assert_eq!(msg.severity, SyslogSeverity::SEV_INFO);
-        assert_eq!(msg.hostname, Some(String::from("host1")));
-        assert_eq!(msg.appname, Some(String::from("CROND")));
-        assert_eq!(msg.procid, Some(message::ProcIdType::PID(10391)));
-        assert_eq!(msg.msg, String::from("some_message"));
-        assert_eq!(msg.timestamp, Some(1452816241));
-        assert_eq!(msg.sd.len(), 2);
-        assert_eq!(msg.sd.find_sdid("meta").expect("should contain meta").len(), 3);
-    }
-
-    #[test]
-    fn test_sd_with_escaped_quote() {
-        let msg_text = r#"<1>1 - - - - - [meta key="val\"ue"] message"#;
-        let msg = parse_message(msg_text).expect("should parse");
-        assert_eq!(msg.sd.find_tuple("meta", "key").expect("Should contain meta key"), r#"val"ue"#);
-    }
-
-    #[test]
-    fn test_other_message() { 
-        let msg_text = r#"<190>1 2016-02-21T01:19:11+00:00 batch6sj - - - [meta sequenceId="21881798" x-group="37051387"][origin x-service="tracking"] metascutellar conversationalist nephralgic exogenetic graphy streng outtaken acouasm amateurism prenotice Lyonese bedull antigrammatical diosphenol gastriloquial bayoneteer sweetener naggy roughhouser dighter addend sulphacid uneffectless ferroprussiate reveal Mazdaist plaudite Australasian distributival wiseman rumness Seidel topazine shahdom sinsion mesmerically pinguedinous ophthalmotonometer scuppler wound eciliate expectedly carriwitchet dictatorialism bindweb pyelitic idic atule kokoon poultryproof rusticial seedlip nitrosate splenadenoma holobenthic uneternal Phocaean epigenic doubtlessly indirection torticollar robomb adoptedly outspeak wappenschawing talalgia Goop domitic savola unstrafed carded unmagnified mythologically orchester obliteration imperialine undisobeyed galvanoplastical cycloplegia quinquennia foremean umbonal marcgraviaceous happenstance theoretical necropoles wayworn Igbira pseudoangelic raising unfrounced lamasary centaurial Japanolatry microlepidoptera"#;
+    fn test_other_message() {
+        let msg_text = r#"<190>Jan 8 12:14:16 batch6sj - - - [meta sequenceId="21881798" x-group="37051387"][origin x-service="tracking"] metascutellar conversationalist nephralgic exogenetic graphy streng outtaken acouasm amateurism prenotice Lyonese bedull antigrammatical diosphenol gastriloquial bayoneteer sweetener naggy roughhouser dighter addend sulphacid uneffectless ferroprussiate reveal Mazdaist plaudite Australasian distributival wiseman rumness Seidel topazine shahdom sinsion mesmerically pinguedinous ophthalmotonometer scuppler wound eciliate expectedly carriwitchet dictatorialism bindweb pyelitic idic atule kokoon poultryproof rusticial seedlip nitrosate splenadenoma holobenthic uneternal Phocaean epigenic doubtlessly indirection torticollar robomb adoptedly outspeak wappenschawing talalgia Goop domitic savola unstrafed carded unmagnified mythologically orchester obliteration imperialine undisobeyed galvanoplastical cycloplegia quinquennia foremean umbonal marcgraviaceous happenstance theoretical necropoles wayworn Igbira pseudoangelic raising unfrounced lamasary centaurial Japanolatry microlepidoptera"#;
         parse_message(msg_text).expect("should parse as text");
     }
 
     #[test]
     fn test_bad_pri() {
-        let msg = parse_message("<4096>1 - - - - - -");
+        let msg = parse_message("<4096>Jan 8 12:14:16 - - - - - -");
         assert!(msg.is_err());
     }
 
     #[test]
-    fn test_bad_match() {
-        // we shouldn't be able to parse RFC3164 messages
+    fn test_good_match() {
+        // we should be able to parse RFC3164 messages
         let msg = parse_message("<134>Feb 18 20:53:31 haproxy[376]: I am a message");
-        assert!(msg.is_err());
-    }
-
-    #[test]
-    fn test_example_timestamps() {
-        // these are the example timestamps in the rfc
-
-        let msg = parse_message("<1>1 1985-04-12T23:20:50.52Z host - - - -")
-            .expect("Should parse empty message");
-        assert_eq!(msg.timestamp, Some(482196050));
-
-        let msg = parse_message("<1>1 1985-04-12T19:20:50.52-04:00 host - - - -")
-            .expect("Should parse empty message");
-        assert_eq!(msg.timestamp, Some(482167250));
-
-        let msg = parse_message("<1>1 2003-08-24T05:14:15.000003-07:00 host - - - -")
-            .expect("Should parse empty message");
-        assert_eq!(msg.timestamp, Some(1061676855));
-
-        let msg = parse_message("<1>1 2003-08-24T05:14:15.000000003-07:00 host - - - -");
-        assert!(msg.is_err(), "expected parse fail");
+        assert!(!msg.is_err());
     }
 }

--- a/src/severity.rs
+++ b/src/severity.rs
@@ -1,7 +1,3 @@
-#[cfg(feature = "rustc-serialize")]
-use rustc_serialize::{Encodable,Encoder};
-
-#[cfg(feature="serde-serialize")]
 use serde::{Serializer, Serialize};
 
 #[derive(Copy,Clone,Debug,PartialEq)]
@@ -52,18 +48,6 @@ impl SyslogSeverity {
     }
 }
 
-
-
-#[cfg(feature = "rustc-serialize")]
-impl Encodable for SyslogSeverity {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error>
-    {
-        s.emit_str(self.as_str())
-    }
-}
-
-
-#[cfg(feature = "serde-serialize")]
 impl Serialize for SyslogSeverity {
     fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
         ser.serialize_str(self.as_str())


### PR DESCRIPTION
 - Removes rustc-serialize (officially deprecated)
 - Modifies message parser
 - Updates benchmarks and tests
 - Does not handle process ID (yet)