### PR TITLE
Passing millis as part of Message for date parsing

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -225,7 +225,7 @@ mod tests {
         // XXX: we don't have a guaranteed order, I don't think, so this might break with minor
         // version changes. *shrug*
         assert_eq!(encoded,
-                   "{\"severity\":\"info\",\"facility\":\"kern\",\"version\":1,\"timestamp\":null,\"hostname\":null,\"appname\":null,\"procid\":null,\"msgid\":null,\"sd\":{},\"msg\":\"\"}");
+                   "{\"severity\":\"info\",\"facility\":\"kern\",\"version\":1,\"timestamp\":null,\"timestamp_millis\":null,\"hostname\":null,\"appname\":null,\"procid\":null,\"msgid\":null,\"sd\":{},\"msg\":\"\"}");
     }
 
     #[test]

--- a/src/message.rs
+++ b/src/message.rs
@@ -212,7 +212,7 @@ mod tests {
             facility: LOG_KERN,
             version: 1,
             timestamp: None,
-            timestamp_millis: None,
+            timestamp_nanos: None,
             hostname: None,
             appname: None,
             procid: None,
@@ -225,7 +225,7 @@ mod tests {
         // XXX: we don't have a guaranteed order, I don't think, so this might break with minor
         // version changes. *shrug*
         assert_eq!(encoded,
-                   "{\"severity\":\"info\",\"facility\":\"kern\",\"version\":1,\"timestamp\":null,\"timestamp_millis\":null,\"hostname\":null,\"appname\":null,\"procid\":null,\"msgid\":null,\"sd\":{},\"msg\":\"\"}");
+                   "{\"severity\":\"info\",\"facility\":\"kern\",\"version\":1,\"timestamp\":null,\"timestamp_nanos\":null,\"hostname\":null,\"appname\":null,\"procid\":null,\"msgid\":null,\"sd\":{},\"msg\":\"\"}");
     }
 
     #[test]

--- a/src/message.rs
+++ b/src/message.rs
@@ -150,7 +150,7 @@ pub struct SyslogMessage {
     pub facility: facility::SyslogFacility,
     pub version: i32,
     pub timestamp: Option<time_t>,
-    pub timestamp_millis: Option<i32>,
+    pub timestamp_nanos: Option<i32>,
     pub hostname: Option<String>,
     pub appname: Option<String>,
     pub procid: Option<ProcId>,

--- a/src/message.rs
+++ b/src/message.rs
@@ -150,6 +150,7 @@ pub struct SyslogMessage {
     pub facility: facility::SyslogFacility,
     pub version: i32,
     pub timestamp: Option<time_t>,
+    pub timestamp_millis: Option<i32>,
     pub hostname: Option<String>,
     pub appname: Option<String>,
     pub procid: Option<ProcId>,

--- a/src/message.rs
+++ b/src/message.rs
@@ -212,6 +212,7 @@ mod tests {
             facility: LOG_KERN,
             version: 1,
             timestamp: None,
+            timestamp_millis: None,
             hostname: None,
             appname: None,
             procid: None,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -335,7 +335,7 @@ fn parse_message_s(m: &str) -> ParseResult<SyslogMessage> {
        facility: fac,
        version,
        timestamp: event_time.map(|t| t.sec),
-       timestamp_millis: event_time.map(|t| t.nsec / NSEC_PER_MS),
+       timestamp_nanos: event_time.map(|t| t.nsec),
        hostname,
        appname,
        procid,
@@ -503,7 +503,7 @@ mod tests {
         assert_eq!(msg.procid, Some(message::ProcId::PID(13894)));
         assert_eq!(msg.msg, String::from(""));
         assert_eq!(msg.timestamp, Some(1526286181));
-        assert_eq!(msg.timestamp_millis, Some(520));
+        assert_eq!(msg.timestamp_nanos, Some(520000000));
         assert_eq!(msg.sd.len(), 1);
         let sd = msg.sd.find_sdid("junos@2636.1.1.1.2.57").expect("should contain root SD");
         let expected = {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,7 +10,7 @@ use time;
 
 use severity;
 use facility;
-use message::{time_t, SyslogMessage, ProcId, StructuredData};
+use message::{SyslogMessage, ProcId, StructuredData};
 
 const NSEC_PER_MS: i32 = 1000000;
 


### PR DESCRIPTION
The current implementation of the message parser discards milliseconds from messages when present (e.g. the message in the [`test_empty_sd_value`](https://github.com/Roguelazer/rust-syslog-rfc5424/blob/d580edfc5ba53abcb185f51f05a5fdc5485c0f19/src/parser.rs#L495) test).  This PR attempts to preserve and pass this information as part of the Message struct via a new `timestamp_millis` value.