### PR TITLE
update rust-syslog-rfc5424 for 2018ed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog_rfc5424"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["James Brown <roguelazer@roguelazer.com>"]
 description = "Parser for RFC5424 (IETF-format) syslog messages"
 documentation = "https://docs.rs/syslog_rfc5424/"
@@ -8,15 +8,14 @@ homepage = "https://github.com/Roguelazer/rust-syslog-rfc5424"
 repository = "https://github.com/Roguelazer/rust-syslog-rfc5424"
 license = "ISC"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 time = "^0.1"
-# this should be a dev dependency, but there's some kind of issue with
-# dev-only macro crates
-assert_matches = "1.0"
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 timeit = "0.1"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This module implements an [RFC 5424](https://tools.ietf.org/html/rfc5424) IETF S
 
 This tool supports serializing the parsed messages using serde if it's built with the `serde-serialize` feature.
 
-
 This library is licensed under the ISC license, a copy of which can be found in [LICENSE.txt](LICENSE.txt)
+
+The minimum supported Rust version for this library is 1.34.
 
 ## Performance
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,24 +30,17 @@
 //!    message. Rust doesn't have a convenient way to only treat *some* of a buffer as utf-8,
 //!    so I'm just not supporting that. Most "real" syslog servers barf on it anway.
 //!
-#[cfg(test)]
-extern crate assert_matches;
-extern crate time;
-#[cfg(feature = "serde-serialize")]
-extern crate serde;
 #[cfg(feature = "serde-serialize")]
 #[macro_use]
 extern crate serde_derive;
-#[cfg(feature = "serde-serialize")]
-extern crate serde_json;
 
-pub mod message;
-mod severity;
 mod facility;
+pub mod message;
 pub mod parser;
+mod severity;
 
-pub use severity::SyslogSeverity;
 pub use facility::SyslogFacility;
+pub use severity::SyslogSeverity;
 
-pub use parser::parse_message;
 pub use message::SyslogMessage;
+pub use parser::parse_message;


### PR DESCRIPTION
- use Rust 2018 edition
- rustfmt various things
- use `thiserror` to generate Error implementations instead of doing it by hand
- adds public `TryFrom` implementations for SyslogSeverity and SyslogFacility
- bump MSRV to 1.34 (for `TryFrom`)

Closes #16 