### PR TITLE
Parameterize the map type used for structured data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,15 @@ serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
+indexmap = { version = "1", optional = true }
+fxhash = { version = "0.2", optional = true }
+
+[features]
+serde-serialize = ["serde", "serde_derive", "serde_json", "indexmap/serde-1"]
+fastmap = ["indexmap", "fxhash"]
 
 [dev-dependencies]
 timeit = "0.1"
-
-[features]
-serde-serialize = ["serde", "serde_derive", "serde_json"]
 
 [badges]
 travis-ci = { repository = "Roguelazer/rust-syslog-rfc5424" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,13 @@ serde_derive = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
 indexmap = { version = "1", optional = true }
-fxhash = { version = "0.2", optional = true }
 
 [features]
 serde-serialize = ["serde", "serde_derive", "serde_json", "indexmap/serde-1"]
-fastmap = ["indexmap", "fxhash"]
 
 [dev-dependencies]
 timeit = "0.1"
+fxhash = "0.2"
 
 [badges]
 travis-ci = { repository = "Roguelazer/rust-syslog-rfc5424" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde-serialize = ["serde", "serde_derive", "serde_json", "indexmap/serde-1"]
 [dev-dependencies]
 timeit = "0.1"
 fxhash = "0.2"
+clap = "2"
 
 [badges]
 travis-ci = { repository = "Roguelazer/rust-syslog-rfc5424" }

--- a/examples/validate_file.rs
+++ b/examples/validate_file.rs
@@ -1,0 +1,94 @@
+/// Read a file of newline-delimited messages and count how many are valid
+use clap::Arg;
+use std::io::{BufRead, BufReader};
+
+use fxhash::FxBuildHasher;
+#[cfg(feature = "indexmap")]
+use indexmap::IndexMap;
+use std::collections::{BTreeMap, HashMap};
+
+use syslog_rfc5424::SyslogMessage;
+
+#[inline(always)]
+fn parse_with_btreemap(s: &str) -> bool {
+    s.parse::<SyslogMessage<BTreeMap<_, _>>>().is_ok()
+}
+
+#[inline(always)]
+fn parse_with_hashmap(s: &str) -> bool {
+    s.parse::<SyslogMessage<HashMap<_, _>>>().is_ok()
+}
+
+#[inline(always)]
+fn parse_with_hashmap_fxhash(s: &str) -> bool {
+    s.parse::<SyslogMessage<HashMap<_, _, FxBuildHasher>>>()
+        .is_ok()
+}
+
+#[inline(always)]
+#[cfg(feature = "indexmap")]
+fn parse_with_indexmap(s: &str) -> bool {
+    s.parse::<SyslogMessage<IndexMap<_, _>>>().is_ok()
+}
+
+#[inline(always)]
+#[cfg(feature = "indexmap")]
+fn parse_with_indexmap_fxhash(s: &str) -> bool {
+    s.parse::<SyslogMessage<IndexMap<_, _, FxBuildHasher>>>()
+        .is_ok()
+}
+
+pub fn main() {
+    let matches = clap::App::new(env!("CARGO_PKG_NAME"))
+        .version(env!("CARGO_PKG_VERSION"))
+        .author("EasyPost <oss@easypost.com>")
+        .about(env!("CARGO_PKG_DESCRIPTION"))
+        .arg(
+            Arg::with_name("map_type")
+                .short("m")
+                .long("map-type")
+                .takes_value(true)
+                .possible_values(&[
+                    "btreemap",
+                    "hashmap",
+                    "hashmap+fxhash",
+                    "indexmap",
+                    "indexmap+fxhash",
+                ])
+                .default_value("btreemap")
+                .help("Map implementation to use"),
+        )
+        .arg(
+            Arg::with_name("input")
+                .takes_value(true)
+                .default_value("-")
+                .help("Path to input file (if '-', reads stdin)"),
+        )
+        .get_matches();
+
+    let s = std::io::stdin();
+
+    let input: Box<dyn BufRead> = match matches.value_of("input").unwrap() {
+        "-" => Box::new(s.lock()),
+        other => Box::new(BufReader::new(std::fs::File::open(other).unwrap())),
+    };
+
+    let f: Box<dyn Fn(&str) -> bool> = match matches.value_of("map_type").unwrap() {
+        "btreemap" => Box::new(parse_with_btreemap),
+        "hashmap" => Box::new(parse_with_hashmap),
+        "hashmap+fxhash" => Box::new(parse_with_hashmap_fxhash),
+        #[cfg(feature = "indexmap")]
+        "indexmap" => Box::new(parse_with_indexmap),
+        #[cfg(feature = "indexmap")]
+        "indexmap+fxhash" => Box::new(parse_with_indexmap_fxhash),
+        _ => unimplemented!("unknown map type!"),
+    };
+
+    let count = input
+        .lines()
+        .filter_map(|line| line.ok())
+        .filter(|line| f(line))
+        .count();
+
+    println!("count ok: {:?}", count);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ mod facility;
 pub mod message;
 pub mod parser;
 mod severity;
+mod structured_data;
 
 pub use facility::SyslogFacility;
 pub use severity::SyslogSeverity;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -383,6 +383,7 @@ mod tests {
     use crate::message;
 
     use crate::facility::SyslogFacility;
+    use crate::message::StructuredDataElement;
     use crate::severity::SyslogSeverity;
 
     #[test]
@@ -550,7 +551,7 @@ mod tests {
             expected
                 .into_iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect::<BTreeMap<_, _>>()
+                .collect::<StructuredDataElement>()
         };
         assert_eq!(sd, &expected);
     }

--- a/src/structured_data.rs
+++ b/src/structured_data.rs
@@ -1,0 +1,152 @@
+#[cfg(feature = "indexmap")]
+use indexmap::IndexMap;
+use std::borrow::Cow;
+use std::collections::{BTreeMap, HashMap};
+use std::hash::BuildHasher;
+
+pub type SDIDType = String;
+pub type SDParamIDType = String;
+pub type SDParamValueType = String;
+
+pub trait StructuredDataElement: Default + std::fmt::Debug {}
+
+impl StructuredDataElement for BTreeMap<SDParamIDType, SDParamValueType> {}
+
+impl<H: Default + Clone + BuildHasher> StructuredDataElement
+    for HashMap<SDParamIDType, SDParamValueType, H>
+{
+}
+
+#[cfg(feature = "indexmap")]
+impl<H: Default> StructuredDataElement for IndexMap<SDParamIDType, SDParamValueType, H> {}
+
+pub trait StructuredDataMap: Clone + PartialEq + Eq + std::fmt::Debug + Default {
+    type StructuredDataElementMap: StructuredDataElement;
+
+    fn find_tuple<'b>(&'b self, sd_id: &str, sd_param_id: &str) -> Option<&'b SDParamValueType>;
+    fn find_sdid<'b>(&'b self, sd_id: &str) -> Option<&'b Self::StructuredDataElementMap>;
+    fn as_btreemap(&self) -> Cow<BTreeMap<SDIDType, BTreeMap<SDParamIDType, SDParamValueType>>>;
+    fn insert_tuple<SI, SPI, SPV>(
+        &mut self,
+        sd_id: SI,
+        sd_param_id: SPI,
+        sd_param_value: SPV,
+    ) -> ()
+    where
+        SI: Into<SDIDType>,
+        SPI: Into<SDParamIDType>,
+        SPV: Into<SDParamValueType>;
+}
+
+pub type BTreeStructuredData = BTreeMap<SDIDType, BTreeMap<SDParamIDType, SDParamValueType>>;
+
+impl StructuredDataMap for BTreeStructuredData {
+    type StructuredDataElementMap = BTreeMap<SDParamIDType, SDParamValueType>;
+
+    fn find_tuple<'b>(&'b self, sd_id: &str, sd_param_id: &str) -> Option<&'b SDParamValueType> {
+        self.get(sd_id).and_then(|submap| submap.get(sd_param_id))
+    }
+
+    fn find_sdid<'b>(&'b self, sd_id: &str) -> Option<&'b Self::StructuredDataElementMap> {
+        self.get(sd_id)
+    }
+
+    fn insert_tuple<SI, SPI, SPV>(&mut self, sd_id: SI, sd_param_id: SPI, sd_param_value: SPV) -> ()
+    where
+        SI: Into<SDIDType>,
+        SPI: Into<SDParamIDType>,
+        SPV: Into<SDParamValueType>,
+    {
+        let sub_map = self.entry(sd_id.into()).or_insert_with(Default::default);
+        sub_map.insert(sd_param_id.into(), sd_param_value.into());
+    }
+
+    fn as_btreemap(
+        &self,
+    ) -> std::borrow::Cow<BTreeMap<SDIDType, BTreeMap<SDParamIDType, SDParamValueType>>> {
+        Cow::Borrowed(&self)
+    }
+}
+
+impl<H: Default + Clone + BuildHasher> StructuredDataMap
+    for HashMap<SDIDType, HashMap<SDParamIDType, SDParamValueType, H>, H>
+{
+    type StructuredDataElementMap = HashMap<SDParamIDType, SDParamValueType, H>;
+
+    fn find_tuple<'b>(&'b self, sd_id: &str, sd_param_id: &str) -> Option<&'b SDParamValueType> {
+        self.get(sd_id).and_then(|submap| submap.get(sd_param_id))
+    }
+
+    fn find_sdid<'b>(&'b self, sd_id: &str) -> Option<&'b Self::StructuredDataElementMap> {
+        self.get(sd_id)
+    }
+
+    fn insert_tuple<SI, SPI, SPV>(&mut self, sd_id: SI, sd_param_id: SPI, sd_param_value: SPV) -> ()
+    where
+        SI: Into<SDIDType>,
+        SPI: Into<SDParamIDType>,
+        SPV: Into<SDParamValueType>,
+    {
+        let sub_map = self.entry(sd_id.into()).or_insert_with(Default::default);
+        sub_map.insert(sd_param_id.into(), sd_param_value.into());
+    }
+
+    fn as_btreemap(
+        &self,
+    ) -> std::borrow::Cow<BTreeMap<SDIDType, BTreeMap<SDParamIDType, SDParamValueType>>> {
+        Cow::Owned(
+            self.into_iter()
+                .map(|(k, sm)| {
+                    (
+                        k.to_owned(),
+                        sm.into_iter()
+                            .map(|(p, v)| (p.to_owned(), v.to_owned()))
+                            .collect::<BTreeMap<_, _>>(),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>(),
+        )
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<H: Clone + Default + BuildHasher> StructuredDataMap
+    for IndexMap<SDIDType, IndexMap<SDParamIDType, SDParamValueType, H>, H>
+{
+    type StructuredDataElementMap = IndexMap<SDParamIDType, SDParamValueType, H>;
+
+    fn find_tuple<'b>(&'b self, sd_id: &str, sd_param_id: &str) -> Option<&'b SDParamValueType> {
+        self.get(sd_id).and_then(|submap| submap.get(sd_param_id))
+    }
+
+    fn find_sdid<'b>(&'b self, sd_id: &str) -> Option<&'b Self::StructuredDataElementMap> {
+        self.get(sd_id)
+    }
+
+    fn insert_tuple<SI, SPI, SPV>(&mut self, sd_id: SI, sd_param_id: SPI, sd_param_value: SPV) -> ()
+    where
+        SI: Into<SDIDType>,
+        SPI: Into<SDParamIDType>,
+        SPV: Into<SDParamValueType>,
+    {
+        let sub_map = self.entry(sd_id.into()).or_insert_with(Default::default);
+        sub_map.insert(sd_param_id.into(), sd_param_value.into());
+    }
+
+    fn as_btreemap(
+        &self,
+    ) -> std::borrow::Cow<BTreeMap<SDIDType, BTreeMap<SDParamIDType, SDParamValueType>>> {
+        Cow::Owned(
+            self.into_iter()
+                .map(|(k, sm)| {
+                    (
+                        k.to_owned(),
+                        sm.into_iter()
+                            .map(|(p, v)| (p.to_owned(), v.to_owned()))
+                            .collect::<BTreeMap<_, _>>(),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>(),
+        )
+    }
+}


### PR DESCRIPTION
This still defaults to `BTreeMap` but allows you to use a `HashMap` (or, if you pass the right feature, an `IndexMap`) instead.

Major breaking API changes (e.g., removal of the deref to BTreeMap, which was kind of dumb anyway).

I added a little command-line program to test different implementations and `BTreeMap` still consistently outperforms `HashMap` and `IndexMap` (even with `fxhash`) for my test data, at least on the ARM64 MacBook Pro I'm currently typing on. Example output:

```
$ time ./target/release/examples/validate_file -m btreemap messages
count ok: 40000

________________________________________________________
Executed in  427.08 millis    fish           external
   usr time  412.84 millis   66.00 micros  412.78 millis
   sys time   12.46 millis  1073.00 micros   11.38 millis

$ time ./target/release/examples/validate_file -m indexmap+fxhash messages
count ok: 40000

________________________________________________________
Executed in  442.98 millis    fish           external
   usr time  428.76 millis   52.00 micros  428.71 millis
   sys time   12.76 millis  895.00 micros   11.87 millis
```

This is intended to address #18 