### PR TITLE
chore: update to rust 2024 edition; modernize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
 
 env:
@@ -13,44 +13,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Install rust
-      uses: actions-rs/toolchain@v1
+      uses: actions/checkout@v5
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        components: rustfmt
-        default: true
-    - name: cargo fmt -- --check
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+        components: rustfmt,clippy
+        toolchain: 1.91.1
+    - uses: Swatinem/rust-cache@v2
+    - name: cargo fmt
+      run: cargo fmt --all -- --check
+    - name: cargo clippy
+      run: cargo clippy -- -D warnings
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: ["1.85.0", stable, beta]
     steps:
-    - uses: actions/checkout@v2
-    - name: Install rust
-      uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v5
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        components: rustfmt
-        default: true
+        toolchain: ${{ matrix.rust }}
+    - uses: Swatinem/rust-cache@v2
     - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
+      run: cargo test --all-features
   audit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install rust
-      uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v5
+    - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        components: rustfmt
-        default: true
-    - name: cargo audit
-      uses: actions-rs/audit-check@v1.2.0
+    - uses: taiki-e/install-action@v2
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        tool: cargo-audit
+    - run: cargo audit
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/Roguelazer/rust-syslog-rfc5424"
 repository = "https://github.com/Roguelazer/rust-syslog-rfc5424"
 license = "ISC"
 readme = "README.md"
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 time = "0.3"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This tool supports serializing the parsed messages using serde if it's built wit
 
 This library is licensed under the ISC license, a copy of which can be found in [LICENSE.txt](LICENSE.txt)
 
-The minimum supported Rust version for this library is 1.34.
+The minimum supported Rust version for this library is 1.85.
 
 ## Performance
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -31,8 +31,8 @@ pub enum ProcId {
 impl PartialOrd for ProcId {
     fn partial_cmp(&self, other: &ProcId) -> Option<Ordering> {
         match (self, other) {
-            (&ProcId::PID(ref s_p), &ProcId::PID(ref o_p)) => Some(s_p.cmp(o_p)),
-            (&ProcId::Name(ref s_n), &ProcId::Name(ref o_n)) => Some(s_n.cmp(o_n)),
+            (ProcId::PID(s_p), ProcId::PID(o_p)) => Some(s_p.cmp(o_p)),
+            (ProcId::Name(s_n), ProcId::Name(o_n)) => Some(s_n.cmp(o_n)),
             _ => None,
         }
     }
@@ -95,9 +95,7 @@ impl StructuredData {
     where
         SI: Into<SDIDType>,
     {
-        self.elements
-            .entry(sd_id.into())
-            .or_insert_with(BTreeMap::new)
+        self.elements.entry(sd_id.into()).or_default()
     }
 
     /// Insert a new (sd_id, sd_param_id) -> sd_value mapping into the StructuredData
@@ -227,8 +225,10 @@ mod tests {
         let encoded = serde_json::to_string(&m).expect("Should encode to JSON");
         // XXX: we don't have a guaranteed order, I don't think, so this might break with minor
         // version changes. *shrug*
-        assert_eq!(encoded,
-                   "{\"severity\":\"info\",\"facility\":\"kern\",\"version\":1,\"timestamp\":null,\"timestamp_nanos\":null,\"hostname\":null,\"appname\":null,\"procid\":null,\"msgid\":null,\"sd\":{},\"msg\":\"\"}");
+        assert_eq!(
+            encoded,
+            "{\"severity\":\"info\",\"facility\":\"kern\",\"version\":1,\"timestamp\":null,\"timestamp_nanos\":null,\"hostname\":null,\"appname\":null,\"procid\":null,\"msgid\":null,\"sd\":{},\"msg\":\"\"}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This does the following:

- Bumps the edition to Rust 2024 (which bumps the MSRV to 1.85)
- Fixes all the new warnings
- Updates the CI to remove all the deprecated `actions-rs` dependencies