### PR TITLE
chore: fix warning in parse_param_value

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -117,7 +117,7 @@ fn parse_sd_id(input: &str) -> ParseResult<(String, &str)> {
 }
 
 /** Parse a `param_value`... a.k.a. a quoted string */
-fn parse_param_value(input: &str) -> ParseResult<(Cow<str>, &str)> {
+fn parse_param_value(input: &'_ str) -> ParseResult<(Cow<'_, str>, &'_ str)> {
     let mut rest = input;
     take_char!(rest, '"');
     // Can't do a 0-copy &str slice here because we need to un-escape escaped quotes


### PR DESCRIPTION
this is annoying

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/parser.rs:120:29
    |
120 | fn parse_param_value(input: &str) -> ParseResult<(Cow<str>, &str)> {
    |                             ^^^^                  ^^^^^^^^  ^^^^ the same lifetime is elided here
    |                             |                     |
    |                             |                     the same lifetime is hidden here
    |                             the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
120 | fn parse_param_value(input: &str) -> ParseResult<(Cow<'_, str>, &str)> {
```